### PR TITLE
Changed empty string to empty objects in createOptions

### DIFF
--- a/EdgeSolution/deployment.template.json
+++ b/EdgeSolution/deployment.template.json
@@ -22,7 +22,7 @@
             "type": "docker",
             "settings": {
               "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
-              "createOptions": ""
+              "createOptions": "{}"
             }
           },
           "edgeHub": {
@@ -43,7 +43,7 @@
             "restartPolicy": "always",
             "settings": {
               "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
-              "createOptions": ""
+              "createOptions": "{}"
             }
           },
           "SampleModule": {
@@ -53,7 +53,7 @@
             "restartPolicy": "always",
             "settings": {
               "image": "${MODULES.SampleModule.amd64}",
-              "createOptions": ""
+              "createOptions": "{}"
             }
           },
           "IoTEdgeBogusDataGenerator": {


### PR DESCRIPTION
Avoid warning on task "Azure IoT Edge - Build module images"

```
2021-06-29T13:21:47.8881490Z Warning: createOptions of module tempSensor should be an object
2021-06-29T13:21:47.8882948Z Warning: createOptions of module SampleModule should be an object
2021-06-29T13:21:47.8885039Z Warning: createOptions of module edgeAgent should be an object
2021-06-29T13:21:47.8886164Z Warning: Errors found during createOptions validation. Please check the logs for details.
```
